### PR TITLE
Enhancement/LockTbodyHeader

### DIFF
--- a/js/widgets/widget-sortTbodies.js
+++ b/js/widgets/widget-sortTbodies.js
@@ -1,6 +1,7 @@
-/*! tablesorter tbody sorting widget (BETA) - 11/22/2015 (v2.24.6)
+/*! tablesorter tbody sorting widget (BETA) - 11/07/2016 (v2.24.7)
  * Requires tablesorter v2.22.2+ and jQuery 1.4+
  * by Rob Garrison
+ * Contributors: Chris Rogers
  */
 /*jshint browser:true, jquery:true, unused:false */
 /*global jQuery: false */
@@ -38,6 +39,17 @@
 					// find parsers for each column
 					ts.sortTbodies.setTbodies( c, wo );
 					ts.updateCache( c, null, c.$tbodies );
+				})
+				.bind('sortEnd', function() {
+					// Moves the head row back to the top of the tbody
+					var lockHead = wo.sortTbody_lockHead;
+					var headClass = '.'+c.cssHeader;
+
+					if ( lockHead ) {
+						c.$table.find( headClass ).each( function(){
+							$( this ).parents( 'tbody' ).prepend( this );
+						});
+					}
 				});
 
 			// detect parsers - in case the table contains only info-only tbodies


### PR DESCRIPTION
Added two new variables to hold the `lockhead` option and the header row class (defined in cssHeader).
If the new widget option `sortTbody_lockHead` is true, the header row will be moved back to the top of the `<tbody>` after sorting, this is intended to be used with the `sortTbody_sortRows` option set to true.
This will allow the `<tbody>` and it's child rows to be sorted while keeping the header row at the top of the `<tbody>`.

Incremented the patch version number since this is a small addition, updated the timestamp and added contributor name.